### PR TITLE
Fixed timer + hints

### DIFF
--- a/app/components/playingfield.js
+++ b/app/components/playingfield.js
@@ -51,6 +51,7 @@ export default class PlayingfieldComponent extends Component {
   @tracked time = 0;
   @tracked finishTime = 0;
   @tracked hintCounter = 0;
+  @tracked hintsActive = 0; // Max 3 since a set contains 3 cards
 
   get hasSet() {
     const combinations = this.k_combinations(this.field, 3);
@@ -159,6 +160,7 @@ export default class PlayingfieldComponent extends Component {
         this.finishTime = this.time;
       }
       this.count += 1;
+      this.hintsActive = 0;
     } else {
       picked.forEach((p) => {
         p.wrong = true;
@@ -174,6 +176,7 @@ export default class PlayingfieldComponent extends Component {
     this.cards = this.getDeck();
     this.field = [...this.getCards(12)];
     this.time = 0;
+    this.hintCounter = 0;
     this.count = 0;
     this.timerTask.perform();
     this.isStarted = true;
@@ -197,7 +200,11 @@ export default class PlayingfieldComponent extends Component {
     const combinations = this.k_combinations(this.field, 3);
     let foundSet = combinations.find((comb) => this.isSet(...comb));
     foundSet[this.hintCounter % 3].hint = true;
-    this.hintCounter++;
+    if (this.hintsActive < 3) {
+      this.hintCounter++;
+      this.hintsActive++;
+    }
+    
   }
 
   @task *timerTask() {

--- a/app/components/playingfield.js
+++ b/app/components/playingfield.js
@@ -49,6 +49,7 @@ export default class PlayingfieldComponent extends Component {
   @tracked selected = [];
   @tracked cards = [];
   @tracked time = 0;
+  @tracked startTime = 0;
   @tracked finishTime = 0;
   @tracked hintCounter = 0;
   @tracked hintsActive = 0; // Max 3 since a set contains 3 cards
@@ -175,7 +176,7 @@ export default class PlayingfieldComponent extends Component {
   @action startGame() {
     this.cards = this.getDeck();
     this.field = [...this.getCards(12)];
-    this.time = 0;
+    this.startTime = Date.now();
     this.hintCounter = 0;
     this.count = 0;
     this.timerTask.perform();
@@ -210,7 +211,7 @@ export default class PlayingfieldComponent extends Component {
   @task *timerTask() {
     while (true) {
       yield timeout(1000);
-      this.time += 1;
+      this.time = Math.floor((Date.now() - this.startTime)/1000);
     }
   }
 }


### PR DESCRIPTION
* Fixed the problem where the timer was inaccurate. 
* Fixed the hint counter not resetting at the start of the game and limited the amount of hints one can ask per set selection (limited to 3)